### PR TITLE
Fix redirect for non-EN browsers

### DIFF
--- a/content/assets/js/lang-redirects.js
+++ b/content/assets/js/lang-redirects.js
@@ -7,8 +7,8 @@ function doRedirect() {
   for (i=0;i<langs.length;i++) {
     if ((userLang == langs[i]) || userLang.startsWith(langs[i]+"-")) {
       window.location.replace(langs[i]+"/"+pageName);
+      return;
     }
-    return;
   }
   window.location.replace(langs[0]+"/"+pageName);
 }


### PR DESCRIPTION
The return; statement is executing after every iteration of the loop, which means your function only ever checks the first language in the array ("en") and then exits. It never gets to check the other languages ("nl", "es", "fr", "pt", "ar",...).

Should only return if language matches