### PR TITLE
Update lang-redirects.js

### DIFF
--- a/content/assets/js/lang-redirects.js
+++ b/content/assets/js/lang-redirects.js
@@ -4,11 +4,12 @@ function doRedirect() {
   var userLang = navigator.language || navigator.userLanguage;
   var path = window.location.pathname;
   var pageName = path.substring(path.lastIndexOf('/') + 1);
+  var suffix = window.location.search + window.location.hash;
   for (i=0;i<langs.length;i++) {
     if ((userLang == langs[i]) || userLang.startsWith(langs[i]+"-")) {
-      window.location.replace(langs[i]+"/"+pageName);
+      window.location.replace(langs[i]+"/"+pageName+suffix);
       return;
     }
   }
-  window.location.replace(langs[0]+"/"+pageName);
+  window.location.replace(langs[0]+"/"+pageName+suffix);
 }


### PR DESCRIPTION
This fixes the redirect to specific anchors in page: 
bookmarks like
https://build.fhir.org/ig/HL7/FHIRPath/index.html#fn-toquantity
should redirect to 
https://build.fhir.org/ig/HL7/FHIRPath/en/index.html#fn-toquantity
and not 
https://build.fhir.org/ig/HL7/FHIRPath/en/index.html
