### PR TITLE
Update French translation and report error

### DIFF
--- a/translations/stringsArtifacts-fr.po
+++ b/translations/stringsArtifacts-fr.po
@@ -225,7 +225,7 @@ msgstr "Structures: Définitions de l'extension"
 # ExtensionDesc
 #: ExtensionDesc
 msgid "These define constraints on FHIR data types for systems conforming to this implementation guide."
-msgstr "Ils définissent des contraintes sur les types de données FHIR pour les systèmes conformes à ce guide d'implémentation."
+msgstr "Ils définissent les extensions FHIR définies dans ce guide d'implémentation."
 
 # ValueSetName
 #: ValueSetName

--- a/translations/stringsBase-fr.po
+++ b/translations/stringsBase-fr.po
@@ -181,7 +181,7 @@ msgstr "Exemples"
 # Raw
 #: Raw
 msgid "Raw %FMT%"
-msgstr "Brut %FMT%"
+msgstr "%FMT% brut"
 
 # Abstract
 #: Abstract

--- a/translations/stringsBase-fr.po
+++ b/translations/stringsBase-fr.po
@@ -391,7 +391,7 @@ msgstr "Version"
 # ResourceDate
 #: ResourceDate
 msgid "as of %RESDATE%"
-msgstr "à partir de %RESDATE%"
+msgstr "à date du %RESDATE%"
 
 # Responsible
 #: Responsible


### PR DESCRIPTION
@lmckenzi FYI there is an error in the extension description : it contains the data type description.

The problem comes from the first template, see https://hl7.org/fhir/us/core/STU5.0.1/artifacts.html#structures-extension-definitions

#: ExtensionDesc
msgid "These define constraints on FHIR data types for systems conforming to this implementation guide."